### PR TITLE
Added ability to manually Flush()

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,9 +1,10 @@
 package posthog
 
 import (
-	"github.com/xtgo/uuid"
 	"net/http"
 	"time"
+
+	"github.com/xtgo/uuid"
 )
 
 // Instances of this type carry the different configuration options that may
@@ -62,6 +63,10 @@ type Config struct {
 	// again.
 	// If not set the client will fallback to use a default retry policy.
 	RetryAfter func(int) time.Duration
+
+	// How long Flush() will attempt to flush its queue for. If FlushMaxWait is
+	// exceeded, Flush() will return FlushMaxWaitErr, nil otherwise.
+	FlushMaxWait time.Duration
 
 	// A function called by the client to generate unique message identifiers.
 	// The client uses a UUID generator if none is provided.


### PR DESCRIPTION
This PR extends the client interface to be able to perform a `Flush()` that will
cause the looper to bypass the ticker, queue length checks etc. and send telemetry
data right away.

This is useful when a service shuts down or exits; especially useful for CLI tools
that may have short runtimes.

NOTE: I did not test ctx usage because it would require adding an interface for
the looper (I think?) to cause the looper to wait and that would require a good
chunk of code changes. Another option - maybe to expose a `LoopFunc` to the config
and allow the client to set it but that seems janky because it would exist almost
purely for tests. :|